### PR TITLE
feat(qtile): add rofi-based Firefox tab picker via brotab integration

### DIFF
--- a/.config/qtile/lib/brotab_picker.py
+++ b/.config/qtile/lib/brotab_picker.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import subprocess
+import threading
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import quote_plus
+
+DEFAULT_GROUP = "e"
+BROWSER_KEYWORD = "firefox"
+
+
+@dataclass(frozen=True)
+class Tab:
+    tab_id: str   # e.g. b.1.7
+    title: str
+    url: str
+
+
+def _run(cmd: List[str], stdin: Optional[str] = None, timeout: Optional[int] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        input=stdin,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _bt_ok() -> bool:
+    p = _run(["bt", "clients"], timeout=2)
+    return p.returncode == 0
+
+
+def _bt_list_tabs() -> List[Tab]:
+    p = _run(["bt", "list"], timeout=4)
+    if p.returncode != 0:
+        return []
+    out: List[Tab] = []
+    for line in p.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        tab_id = parts[0].strip()
+        title = parts[1].strip()
+        url = parts[2].strip()
+        if tab_id and title:
+            out.append(Tab(tab_id, title, url))
+    return out
+
+
+def _rofi_pick(lines: List[str]) -> str:
+    # user interaction: allow long timeout
+    p = _run(
+        ["rofi", "-dmenu", "-i", "-p", "Firefox tab / search"],
+        stdin="\n".join(lines) + "\n",
+        timeout=None,
+    )
+    return (p.stdout or "").strip()
+
+
+def _window_prefix(tab_id: str) -> str:
+    # b.1.7 -> b.1
+    parts = tab_id.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else tab_id
+
+
+def _qtile_firefox_windows(qtile) -> List[Tuple[str, str]]:
+    """
+    Return list of (group_name, window_title_full) for firefox windows.
+    This reads Qtile internal state directly (no cmd-obj).
+    """
+    res: List[Tuple[str, str]] = []
+
+    # qtile.windows_map: {wid: Window}
+    # window has .wm_class and .name, and belongs to a group
+    for w in getattr(qtile, "windows_map", {}).values():
+        try:
+            wm_class = w.get_wm_class() or []
+        except Exception:
+            wm_class = getattr(w, "wm_class", []) or []
+
+        wm_s = ",".join(wm_class) if isinstance(wm_class, (list, tuple)) else str(wm_class)
+        if BROWSER_KEYWORD not in wm_s.lower():
+            continue
+
+        group = getattr(w, "group", None)
+        group_name = getattr(group, "name", "") if group else ""
+
+        title_full = (getattr(w, "name", "") or "").replace("\n", " ").strip()
+        if group_name and title_full:
+            res.append((group_name, title_full))
+
+    return res
+
+
+def _build_prefix_to_group_map(qtile, tabs: List[Tab]) -> Dict[str, str]:
+    """
+    Match rule kamu:
+    - bt tab.title harus jadi prefix dari Qtile Firefox window title
+    - hasil mapping: window_prefix(tab_id) -> group_name
+    """
+    ff = _qtile_firefox_windows(qtile)
+
+    mapping: Dict[str, str] = {}
+    for t in tabs:
+        wp = _window_prefix(t.tab_id)
+        if wp in mapping:
+            continue
+
+        for g, full_title in ff:
+            # case-sensitive prefix match (aman buat "\xxx")
+            if full_title.startswith(t.title):
+                mapping[wp] = g
+                break
+
+    return mapping
+
+
+def go_to_group(name: str):
+    """
+    Copy dari logic kamu.
+    """
+    def _inner(qtile):
+        if len(qtile.screens) == 1:
+            qtile.groups_map[name].toscreen()
+            return
+
+        if name.isdigit() and name != "0":
+            qtile.groups_map[name].toscreen(1)
+        else:
+            qtile.groups_map[name].toscreen(0)
+
+    return _inner
+
+
+def _call_in_qtile_thread(qtile, fn) -> None:
+    """
+    Schedule fn to run on Qtile event loop thread safely.
+    Tries multiple attributes depending on Qtile version.
+    """
+    # Newer Qtile often has _eventloop (asyncio loop)
+    loop = getattr(qtile, "_eventloop", None)
+    if loop is not None:
+        try:
+            loop.call_soon_threadsafe(fn)
+            return
+        except Exception:
+            pass
+
+    # Fallback: some builds have call_soon
+    call_soon = getattr(qtile, "call_soon", None)
+    if callable(call_soon):
+        try:
+            call_soon(fn)
+            return
+        except Exception:
+            pass
+
+    # Last resort (not ideal): call directly (may be wrong thread)
+    try:
+        fn()
+    except Exception:
+        pass
+
+
+def brotab_rofi(qtile) -> None:
+    """
+    Non-blocking entry for Key(..., lazy.function(brotab_rofi))
+    All heavy work runs in a thread.
+    """
+    def worker():
+        if not _bt_ok():
+            return
+
+        tabs = _bt_list_tabs()
+        if not tabs:
+            return
+
+        menu_lines = [f"{t.tab_id} {t.title} {t.url}" for t in tabs]
+
+        # Build mapping BEFORE rofi so we don't touch Qtile state after user waits.
+        # (still safe either way, but this keeps qtile access short)
+        prefix_to_group = _build_prefix_to_group_map(qtile, tabs)
+
+        chosen = _rofi_pick(menu_lines)
+
+        # cancel/empty -> default group
+        if not chosen:
+            _call_in_qtile_thread(qtile, lambda: go_to_group(DEFAULT_GROUP)(qtile))
+            return
+
+        # exact match -> activate tab
+        if chosen in set(menu_lines):
+            tab_id = chosen.split()[0].strip()
+            wp = _window_prefix(tab_id)
+            target_group = prefix_to_group.get(wp, DEFAULT_GROUP)
+
+            # 1) move to group via qtile object (main thread)
+            _call_in_qtile_thread(qtile, lambda: go_to_group(target_group)(qtile))
+
+            # 2) activate tab (external)
+            _run(["bt", "activate", tab_id], timeout=3)
+            return
+
+        # otherwise: query
+        query = chosen.strip()
+        if not query:
+            _call_in_qtile_thread(qtile, lambda: go_to_group(DEFAULT_GROUP)(qtile))
+            return
+
+        _call_in_qtile_thread(qtile, lambda: go_to_group(DEFAULT_GROUP)(qtile))
+
+        url = f"https://www.google.com/search?q={quote_plus(query)}"
+
+        # pick a prefix mapped to DEFAULT_GROUP
+        open_prefix = ""
+        for wp, g in prefix_to_group.items():
+            if g == DEFAULT_GROUP:
+                open_prefix = wp
+                break
+
+        if not open_prefix:
+            # fallback: first bt client prefix
+            p = _run(["bt", "clients"], timeout=2)
+            first = (p.stdout.splitlines()[:1] or [""])[0].strip()
+            cid = (first.split()[:1] or [""])[0]  # e.g b.1.33
+            open_prefix = _window_prefix(cid) if cid else ""
+
+        if not open_prefix:
+            return
+
+        _run(["bt", "open", open_prefix], stdin=url + "\n", timeout=3)
+
+    threading.Thread(target=worker, daemon=True).start()

--- a/.config/qtile/my_keybinding.py
+++ b/.config/qtile/my_keybinding.py
@@ -5,6 +5,7 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 
 from constant import ALTERKEY, MOD, SECONDARY_TERMINAL, TERMINAL
+from lib.brotab_picker import brotab_rofi
 
 
 def go_to_group(name: str):
@@ -27,18 +28,21 @@ def get_my_keybinding(groups):
     HOME = os.path.expanduser("~")
 
     keys = [
-
         Key([MOD], "r", lazy.spawn("rofi -show drun"), desc="spawn rofi"),
-
         Key([], "Print", lazy.spawn("flameshot gui"), desc="Launch screenshot"),
-        Key([ALTERKEY], "Return", lazy.spawn(
-            TERMINAL), desc="Launch terminal"),
+        Key([ALTERKEY], "Return", lazy.spawn(TERMINAL), desc="Launch terminal"),
         # Key(
         #     [ALTERKEY], "Return",
         #     lazy.spawn(f"{HOME}/.config/qtile/urxvtc.sh"),
         # ),
-        Key([ALTERKEY], "slash", lazy.spawn(
-            SECONDARY_TERMINAL), desc="Launch terminal"),
+        # Key([ALTERKEY], "slash", lazy.spawn(
+        #     SECONDARY_TERMINAL), desc="Launch terminal"),
+        Key(
+            [ALTERKEY],
+            "slash",
+            lazy.function(brotab_rofi),
+            desc="Pick Firefox tab via rofi (brotab)",
+        ),
         Key([ALTERKEY], "delete", lazy.window.kill(), desc="Kill focused window"),
         Key(
             [ALTERKEY],
@@ -52,10 +56,8 @@ def get_my_keybinding(groups):
             lazy.window.toggle_fullscreen(),
             desc="Toggle fullscreen on the focused window",
         ),
-        Key([ALTERKEY], 'space', lazy.next_screen(), desc='Next monitor'),
-
-        Key([ALTERKEY], "escape", lazy.next_layout(),
-            desc="Toggle between layouts"),
+        Key([ALTERKEY], "space", lazy.next_screen(), desc="Next monitor"),
+        Key([ALTERKEY], "escape", lazy.next_layout(), desc="Toggle between layouts"),
         # Rofi
         Key([MOD], "r", lazy.spawn("rofi -show drun"), desc="spawn rofi"),
         #
@@ -82,8 +84,9 @@ def get_my_keybinding(groups):
             lazy.layout.shuffle_right(),
             desc="Move window to the right",
         ),
-        Key([MOD, "shift"], "down", lazy.layout.shuffle_down(),
-            desc="Move window down"),
+        Key(
+            [MOD, "shift"], "down", lazy.layout.shuffle_down(), desc="Move window down"
+        ),
         Key([MOD, "shift"], "down", lazy.layout.shuffle_up(), desc="Move window up"),
         # Grow windows. If current window is on the edge of screen and direction
         # will be to screen edge - window would shrink.
@@ -97,10 +100,15 @@ def get_my_keybinding(groups):
             lazy.spawn("playerctl play-pause"),
             desc="Media play/pause",
         ),
-        Key([ALTERKEY], "n", lazy.spawn(
-            "playerctl position 10-"), desc="back 10 second"),
-        Key([ALTERKEY], "m", lazy.spawn(
-            "playerctl position 10+"), desc="forward 10 second"),
+        Key(
+            [ALTERKEY], "n", lazy.spawn("playerctl position 10-"), desc="back 10 second"
+        ),
+        Key(
+            [ALTERKEY],
+            "m",
+            lazy.spawn("playerctl position 10+"),
+            desc="forward 10 second",
+        ),
         Key([MOD, "control"], "r", lazy.restart(), desc="Restart Qtile"),
         Key([MOD, "control"], "delete", lazy.shutdown(), desc="Shutdown Qtile"),
         Key(
@@ -117,15 +125,13 @@ def get_my_keybinding(groups):
         Key(
             [],
             "XF86MonBrightnessUp",
-            lazy.spawn(
-                f"{HOME}/.config/qtile/scripts/brightness.sh brightness_up"),
+            lazy.spawn(f"{HOME}/.config/qtile/scripts/brightness.sh brightness_up"),
             desc="brightness UP",
         ),
         Key(
             [],
             "XF86MonBrightnessDown",
-            lazy.spawn(
-                f"{HOME}/.config/qtile/scripts/brightness.sh brightness_down"),
+            lazy.spawn(f"{HOME}/.config/qtile/scripts/brightness.sh brightness_down"),
             desc="brightness Down",
         ),
     ]
@@ -134,8 +140,7 @@ def get_my_keybinding(groups):
         keys.extend(
             [
                 # ALTERKEY + group name = switch to group
-                Key([ALTERKEY], group.name, lazy.function(
-                    go_to_group(group.name))),
+                Key([ALTERKEY], group.name, lazy.function(go_to_group(group.name))),
                 # MOD + shift + number of group = move focused window to group
                 Key(
                     [MOD, "shift"],

--- a/.config/qtile/my_screen.py
+++ b/.config/qtile/my_screen.py
@@ -37,7 +37,7 @@ def main_bar(visible_groups, device):
     bar = [
         widget.Sep(padding=5, linewidth=0),
         widget.Image(
-            filename="~/.config/qtile/assets/icons/linux1.png",
+            filename="~/.config/qtile/assets/icons/main-2.png",
             margin=6,
             mouse_callbacks={"Button1": lambda: qtile.cmd_spawn("rofi -show drun")},
         ),

--- a/.config/qtile/scripts/brotab.sh.bak
+++ b/.config/qtile/scripts/brotab.sh.bak
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_GROUP="e"
+
+# brotab must be available
+bt clients >/dev/null 2>&1 || exit 0
+
+tabs="$(bt list 2>/dev/null || true)"
+[ -z "${tabs:-}" ] && exit 0
+
+# rofi-friendly (brotab uses \t delimiters)
+menu_lines="$(printf "%s\n" "$tabs" | tr '\t' ' ')"
+
+# --- Build mapping: window_prefix (e.g., b.1) -> qtile group (e.g., e)
+# Strategy:
+# - Get Qtile root.windows JSON
+# - Keep only Firefox windows with their group + full title
+# - Compare against bt list titles; if bt_title is prefix of qtile_title, map tab window_prefix -> group
+
+qtile_windows_json="$(qtile cmd-obj -o root -f windows 2>/dev/null || true)"
+
+# Print mapping lines: "b.1<TAB>e"
+map_lines="$(
+  python3 - "$qtile_windows_json" "$tabs" <<'PY' 2>/dev/null || true
+import sys, json, re
+
+qtile_raw = sys.argv[1].strip()
+bt_raw = sys.argv[2]
+
+if not qtile_raw.startswith("["):
+    sys.exit(0)
+
+wins = json.loads(qtile_raw)
+
+# Collect firefox windows: list of (group, title_full)
+ff = []
+for w in wins:
+    wm = w.get("wm_class") or []
+    wm_s = ",".join(wm) if isinstance(wm, list) else str(wm)
+    if "firefox" not in wm_s.lower():
+        continue
+    g = w.get("group") or ""
+    title = (w.get("name") or "").replace("\n", " ").strip()
+    if g and title:
+        ff.append((g, title))
+
+# Helper: get window prefix from tab_id "b.1.3" -> "b.1"
+def window_prefix(tab_id: str) -> str:
+    parts = tab_id.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else tab_id
+
+# Parse bt list lines: tab_id \t title \t url
+# Map prefix -> group (first match wins)
+seen = set()
+for line in bt_raw.splitlines():
+    if not line.strip():
+        continue
+    parts = line.split("\t")
+    if len(parts) < 2:
+        continue
+    tab_id = parts[0].strip()
+    tab_title = parts[1].strip()
+    if not tab_id or not tab_title:
+        continue
+
+    wp = window_prefix(tab_id)
+    if wp in seen:
+        continue
+
+    # Match: bt tab_title is prefix of qtile window title (case-sensitive as title often contains symbols like \)
+    # Example:
+    # bt: "Qtile browser window list"
+    # qtile: "Qtile browser window list — Original profile — Mozilla Firefox"
+    for g, full_title in ff:
+        if full_title.startswith(tab_title):
+            print(f"{wp}\t{g}")
+            seen.add(wp)
+            break
+PY
+)"
+
+declare -A PREFIX_TO_GROUP=()
+if [ -n "${map_lines:-}" ]; then
+  while IFS=$'\t' read -r wp grp; do
+    [ -z "${wp:-}" ] && continue
+    [ -z "${grp:-}" ] && continue
+    PREFIX_TO_GROUP["$wp"]="$grp"
+  done <<<"$map_lines"
+fi
+
+# --- rofi choose
+input="$(
+  printf "%s\n" "$menu_lines" \
+  | rofi -dmenu -i -p "Firefox tab / search"
+)"
+
+# If empty/cancel -> focus default group
+if [ -z "${input:-}" ]; then
+  qtile cmd-obj -o group "$DEFAULT_GROUP" -f toscreen >/dev/null 2>&1 || true
+
+  exit 0
+fi
+
+# If selected an existing tab line -> activate tab and focus mapped group by window prefix
+if printf "%s\n" "$menu_lines" | grep -Fxq -- "$input"; then
+  tab_id="$(printf "%s" "$input" | awk '{print $1}')"
+  [ -z "${tab_id:-}" ] && exit 0
+
+  # window prefix: b.1.3 -> b.1
+  wp="$(printf "%s" "$tab_id" | awk -F'.' '{print $1"."$2}')"
+  target_group="${PREFIX_TO_GROUP[$wp]:-$DEFAULT_GROUP}"
+
+  qtile cmd-obj -o group "$target_group" -f toscreen >/dev/null 2>&1 || true
+  bt activate "$tab_id"
+  exit 0
+fi
+
+# Otherwise: treat as search query -> focus default group, then open google search in a sensible window prefix
+qtile cmd-obj -o group "$DEFAULT_GROUP" -f toscreen >/dev/null 2>&1 || true
+
+query="$(printf "%s" "$input" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+[ -z "${query:-}" ] && exit 0
+
+encoded_q="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote_plus(sys.argv[1]))' "$query")"
+url="https://www.google.com/search?q=${encoded_q}"
+
+# Prefer opening in a window prefix that maps to DEFAULT_GROUP, if any.
+open_prefix=""
+for k in "${!PREFIX_TO_GROUP[@]}"; do
+  if [ "${PREFIX_TO_GROUP[$k]}" = "$DEFAULT_GROUP" ]; then
+    open_prefix="$k"
+    break
+  fi
+done
+
+# Fallback: first available prefix from bt clients
+if [ -z "${open_prefix:-}" ]; then
+  open_prefix="$(bt clients | head -n1 | awk '{print $1}' | cut -d. -f1-2)"
+fi
+[ -z "${open_prefix:-}" ] && exit 0
+
+bt open "$open_prefix" <<EOF
+$url
+EOF

--- a/.config/qtile/scripts/change_wp.sh
+++ b/.config/qtile/scripts/change_wp.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 # TARGET_DIR="$HOME/.config/qtile/assets"
-TARGET_DIR="$HOME/eos-dotfiles/.config/qtile/assets"
+TARGET_DIR="$HOME/qtile-config/.config/qtile/assets"
 TARGET_FILE="$TARGET_DIR/wallpaper.png"
+
+SECOND_TARGET_DIR="$HOME/.config/qtile/assets"
+SECOND_TARGET_FILE="$SECOND_TARGET_DIR/wallpaper.png"
 
 WALLPAPER=$(yad --file --add-preview --large-preview \
   --title="Select Wallpaper" \
@@ -12,7 +15,10 @@ WALLPAPER=$(yad --file --add-preview --large-preview \
 
 [[ -z "$WALLPAPER" ]] && exit 0
 
-mkdir -p "$TARGET_DIR"
-cp "$WALLPAPER" "$TARGET_FILE"
-feh --no-fehbg --bg-scale "$TARGET_FILE"
+# mkdir -p "$TARGET_DIR"
+# cp "$WALLPAPER" "$TARGET_FILE"
 
+mkdir -p "$SECOND_TARGET_DIR"
+cp "$WALLPAPER" "$SECOND_TARGET_FILE"
+
+feh --no-fehbg --bg-scale "$SECOND_TARGET_FILE"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+### Firefox Tab Integration (Brotab Setup)
+This Qtile configuration includes integration with Firefox tab switching using Brotab, allowing users to search and switch browser tabs directly from Qtile via rofi.
+
+Before using this feature, Brotab must be properly configured.
+
+#### 1. Install Python via asdf (Recommended)
+This configuration expects a modern Python version managed via asdf.
+
+Install Python:
+
+```bash
+asdf plugin add python https://github.com/asdf-community/asdf-python.git
+asdf install python 3.13.0
+asdf set -u python 3.13.0
+```
+
+Verify installation:
+
+```bash
+python3.13 --version
+```
+
+#### 2. Install Firefox Brotab Extension
+Install the Brotab extension for Firefox:
+https://addons.mozilla.org/en-US/firefox/addon/brotab/
+After installation, restart Firefox.
+
+#### 3. Install Brotab CLI via pipx
+Install Brotab CLI using pipx to keep it isolated from the system Python:
+
+```bash
+pipx uninstall brotab
+pipx install brotab --python python3.13
+```
+
+Verify installation:
+
+```bash
+bt --version
+bt clients
+bt list
+```
+
+If bt list shows your Firefox tabs, the setup is working correctly.
+
+#### 4. Additional Dependency (Arch Linux)
+On Arch Linux systems, Brotab requires the following package:
+
+```bash
+sudo pacman -S python-lz4
+```
+
+#### 5. Install pipx (if not installed)
+
+```bash
+sudo pacman -S python-pipx
+pipx install brotab
+pipx ensurepath
+```
+
+#### What does pipx ensurepath do?
+This command checks whether the directory:
+
+```bash
+~/.local/bin
+```
+
+
+is included in your shell's PATH.
+
+If not, pipx automatically adds a line to your shell configuration file such as:
+
+```bash
+~/.bashrc
+~/.zshrc
+or other shell config
+```
+
+containing:
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+This allows commands like bt to be executed directly in the terminal.
+
+#### 6. Final Verification
+
+Run:
+
+```bash
+bt clients
+bt list
+```
+
+If your Firefox tabs are listed, the Qtile browser picker integration is ready to use.
+
+Troubleshooting
+
+If Firefox is running but bt list shows no tabs:
+- Ensure Firefox was restarted after installing the extension.
+- Ensure only one Firefox profile instance is running.
+- Confirm the Brotab extension is enabled in Firefox.

--- a/packages-needed.txt
+++ b/packages-needed.txt
@@ -3,7 +3,6 @@ qtile
 ttf-cascadia-code
 arc-gtk-theme-eos
 pcmanfm-gtk3
-picom
 alsa-utils
 papirus-icon-theme
 pasystray


### PR DESCRIPTION
- Introduce brotab_picker module to list/activate Firefox tabs and open search queries from rofi
- Bind Alt+Slash to the new brotab rofi picker and clean up keybinding formatting
- Update bar icon asset path and adjust wallpaper change script to target ~/.config/qtile/assets
- Add README documenting brotab setup (asdf Python + pipx + Arch dependency) and drop picom from packages list